### PR TITLE
CI(pytest): Run pytest tests with Python 3.13

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,9 +20,9 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
-          - '3.8'
-          - '3.10'
+          - '3.9'
           - '3.12'
+          - '3.13'
       fail-fast: true
 
     runs-on: ${{ matrix.os }}
@@ -38,6 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          allow-prereleases: true
 
       - name: Install non-Python dependencies
         run: |


### PR DESCRIPTION
Replace Pytest 3.8 by Python 3.9