### PR TITLE
CI(OSGeo4W): Add -pipe to CFLAGS and CXXFLAGS to reduce build time

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,17 +59,17 @@ jobs:
       - name: Create installation directory
         run: mkdir $HOME/install
       - name: Build and install
-        shell: bash -l {0}
+        shell: micromamba-shell {0}
         run: source ./.github/workflows/macos_install.sh $HOME/install
       - name: Add the bin directory to PATH
         run: echo "$HOME/install/bin" >> $GITHUB_PATH
       - name: Check installed version
         if: ${{ !cancelled() }}
-        shell: bash -l {0}
+        shell: micromamba-shell {0}
         run: source ./.github/workflows/print_versions.sh
 
       - name: Run pytest with multiple workers in parallel
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
@@ -78,7 +78,7 @@ jobs:
             -ra . \
             -m 'not needs_solo_run'
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
@@ -87,7 +87,7 @@ jobs:
             -m 'needs_solo_run'
 
       - name: Run gunittest tests
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           grass --tmp-project XY --exec \
               g.download.project url=${{ env.SampleData }} path=$HOME

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -66,7 +66,10 @@ jobs:
 
       - name: Compile GRASS GIS
         shell: msys2 {0}
-        run: .github/workflows/build_osgeo4w.sh
+        run: |
+          export CFLAGS="${CFLAGS} -pipe"
+          export CXXFLAGS="${CXXFLAGS} -pipe"
+          .github/workflows/build_osgeo4w.sh
 
       - name: Print installed versions
         if: always()

--- a/lib/linkm/test/try.c
+++ b/lib/linkm/test/try.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     exit(0);
 }
 
-int add_link_rev(struct link *List, struct link *link)
+void add_link_rev(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -70,7 +70,7 @@ int add_link_rev(struct link *List, struct link *link)
     link->next = p;
 }
 
-int add_link(struct link *List, struct link *link)
+void add_link(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -81,7 +81,7 @@ int add_link(struct link *List, struct link *link)
     link->next = NULL;
 }
 
-int dumplist(struct link *List)
+void dumplist(struct link *List)
 {
     struct link *p;
 

--- a/lib/linkm/test/try2.c
+++ b/lib/linkm/test/try2.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     exit(0);
 }
 
-int add_link_rev(struct link *List, struct link *link)
+void add_link_rev(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -72,7 +72,7 @@ int add_link_rev(struct link *List, struct link *link)
     link->next = p;
 }
 
-int add_link(struct link *List, struct link *link)
+void add_link(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -83,7 +83,7 @@ int add_link(struct link *List, struct link *link)
     link->next = NULL;
 }
 
-int dumplist(struct link *List)
+void dumplist(struct link *List)
 {
     struct link *p;
 


### PR DESCRIPTION
With the current GitHub Hosted runners, the build step time is reduced by about 2 minutes, down to about 8min30 instead of about 10min30, for the couple builds I observed