### PR TITLE
Potential fix for code scanning alert no. 239: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/raster/r.to.rast3elev/main.c
+++ b/raster/r.to.rast3elev/main.c
@@ -408,7 +408,7 @@ int main(int argc, char *argv[])
 
     /*Set the upper value */
     if (param.upper->answer) {
-        if (sscanf(param.upper->answer, "%lf", &db.upper))
+        if (sscanf(param.upper->answer, "%lf", &db.upper) == 1)
             db.useUpperVal = 2;
         else
             G_fatal_error(_("The upper value is not valid"));
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
 
     /*Set the lower value */
     if (param.lower->answer) {
-        if (sscanf(param.lower->answer, "%lf", &db.lower))
+        if (sscanf(param.lower->answer, "%lf", &db.lower) == 1)
             db.useLowerVal = 2;
         else
             G_fatal_error(_("The lower value is not valid"));


### PR DESCRIPTION
Potential fix for [https://github.com/echoix/grass/security/code-scanning/239](https://github.com/echoix/grass/security/code-scanning/239)

The correct fix is to validate `sscanf` return values against the exact expected number of matched items, not just truthiness.

In `raster/r.to.rast3elev/main.c`, update both numeric parsing checks:

- Line around `if (sscanf(param.upper->answer, "%lf", &db.upper))`
- Line around `if (sscanf(param.lower->answer, "%lf", &db.lower))`

Change each condition to `== 1`, since each call expects exactly one `%lf` conversion. This preserves existing behavior for valid input while correctly rejecting parse failures and any non-success return values (including `EOF`).

No new methods, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
